### PR TITLE
gRPC server side - error reports (Fix Bugsnag)

### DIFF
--- a/lib/grpc/adapter/cowboy/handler.ex
+++ b/lib/grpc/adapter/cowboy/handler.ex
@@ -36,7 +36,7 @@ defmodule GRPC.Adapter.Cowboy.Handler do
         compressor: compressor
       }
 
-      pid = spawn_link(__MODULE__, :call_rpc, [server, path, stream])
+      pid = :proc_lib.spawn_link(__MODULE__, :call_rpc, [server, path, stream])
       Process.flag(:trap_exit, true)
 
       req = :cowboy_req.set_resp_headers(HTTP2.server_headers(stream), req)

--- a/lib/grpc/adapter/cowboy/handler_error.ex
+++ b/lib/grpc/adapter/cowboy/handler_error.ex
@@ -1,0 +1,20 @@
+defmodule GRPC.Adapter.Cowboy.HandlerError do
+  defexception [:req, :kind, :reason, :stack]
+
+  def new(req, %{__exception__: _} = e, stack \\ []) do
+    exception(req: req, kind: :error, reason: e, stack: stack)
+  end
+
+  def exception(params) when is_list(params) do
+    struct(__MODULE__, params)
+  end
+
+  def message(%{req: req, kind: kind, reason: reason, stack: stack}) do
+    path = :cowboy_req.path(req)
+    "While handling #{path}:\n  " <> Exception.format_banner(kind, reason, stack)
+  end
+
+  def reraise(%__MODULE__{} = error) do
+    :erlang.raise(:error, error, error.stack)
+  end
+end

--- a/test/grpc/integration/server_test.exs
+++ b/test/grpc/integration/server_test.exs
@@ -40,6 +40,10 @@ defmodule GRPC.Integration.ServerTest do
       raise "unknown error(This is a test, please ignore it)"
     end
 
+    def say_hello(%{name: "bad protobuf"}, _stream) do
+      Helloworld.HelloReply.new(message: DateTime.utc_now())
+    end
+
     def say_hello(_req, _stream) do
       raise GRPC.RPCError, status: GRPC.Status.unauthenticated(), message: "Please authenticate"
     end
@@ -115,6 +119,8 @@ defmodule GRPC.Integration.ServerTest do
   end
 
   test "return errors for unknown errors" do
+    attach_error_handler()
+
     run_server([HelloErrorServer], fn port ->
       {:ok, channel} = GRPC.Stub.connect("localhost:#{port}")
       req = Helloworld.HelloRequest.new(name: "unknown error")
@@ -122,6 +128,23 @@ defmodule GRPC.Integration.ServerTest do
       assert {:error,
               %GRPC.RPCError{message: "Internal Server Error", status: GRPC.Status.unknown()}} ==
                channel |> Helloworld.Greeter.Stub.say_hello(req)
+
+      assert_receive {:error_report, _}
+    end)
+  end
+
+  test "return errors for unknown errors in library code" do
+    attach_error_handler()
+
+    run_server([HelloErrorServer], fn port ->
+      {:ok, channel} = GRPC.Stub.connect("localhost:#{port}")
+      req = Helloworld.HelloRequest.new(name: "bad protobuf")
+
+      assert {:error,
+              %GRPC.RPCError{message: "Internal Server Error", status: GRPC.Status.unknown()}} ==
+               channel |> Helloworld.Greeter.Stub.say_hello(req)
+
+      assert_receive {:error_report, _}
     end)
   end
 
@@ -145,6 +168,8 @@ defmodule GRPC.Integration.ServerTest do
   end
 
   test "return deadline error for slow server" do
+    attach_error_handler()
+
     run_server([TimeoutServer], fn port ->
       {:ok, channel} = GRPC.Stub.connect("localhost:#{port}")
       rect = Routeguide.Rectangle.new()
@@ -152,6 +177,8 @@ defmodule GRPC.Integration.ServerTest do
 
       assert {:error, ^error} =
                channel |> Routeguide.RouteGuide.Stub.list_features(rect, timeout: 500)
+
+      assert_receive {:error_report, _}, 10000
     end)
   end
 

--- a/test/grpc/integration/server_test.exs
+++ b/test/grpc/integration/server_test.exs
@@ -149,11 +149,15 @@ defmodule GRPC.Integration.ServerTest do
   end
 
   test "returns appropriate error for stream requests" do
+    attach_error_handler()
+
     run_server([FeatureErrorServer], fn port ->
       {:ok, channel} = GRPC.Stub.connect("localhost:#{port}")
       rect = Routeguide.Rectangle.new()
       error = %GRPC.RPCError{message: "Please authenticate", status: 16}
       assert {:error, ^error} = channel |> Routeguide.RouteGuide.Stub.list_features(rect)
+
+      assert_receive {:error_report, _}
     end)
   end
 
@@ -178,7 +182,7 @@ defmodule GRPC.Integration.ServerTest do
       assert {:error, ^error} =
                channel |> Routeguide.RouteGuide.Stub.list_features(rect, timeout: 500)
 
-      assert_receive {:error_report, _}, 10000
+      assert_receive {:error_report, _}
     end)
   end
 

--- a/test/support/integration_test_case.ex
+++ b/test/support/integration_test_case.ex
@@ -50,4 +50,34 @@ defmodule GRPC.Integration.TestCase do
         result
     end
   end
+
+  defmodule ErrorHandler do
+    @behaviour :gen_event
+
+    def init(test_case_pid), do: {:ok, %{test_case_pid: test_case_pid}}
+
+    def handle_call(_, state) do
+      {:ok, :ok, state}
+    end
+
+    def handle_event({:error_report, _gl, {_pid, _type, [message | _]}}, state)
+        when is_list(message) do
+      error_info = message[:error_info]
+      send(state.test_case_pid, {:error_report, error_info})
+
+      {:ok, state}
+    end
+
+    def handle_event({_level, _gl, _event}, state) do
+      {:ok, state}
+    end
+  end
+
+  def attach_error_handler do
+    :error_logger.add_report_handler(ErrorHandler, self())
+
+    on_exit(fn ->
+      :error_logger.delete_report_handler(ErrorHandler)
+    end)
+  end
 end


### PR DESCRIPTION
Crashes weren't being picked up by [bugsnag-elixir](https://github.com/jarednorman/bugsnag-elixir)

- Updated `GRPC.Adapter.Cowboy.Handler` to use `:proc_lib.spawn_link/3` so that error reports get logged

- When sending back a `"Deadline expired"` response to the client, kicked off a dummy process so an error gets reported