### PR TITLE
EDGE-264: Add cowboy backwards compatibility

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule GRPC.Mixfile do
   defp deps do
     [
       {:protobuf, "~> 0.5"},
-      {:cowboy, "~> 2.8.0"},
+      {:cowboy, ">= 2.7.0"},
       {:gun, "~> 2.0.0", hex: :grpc_gun},
       # 2.9.0 fixes some important bugs, so it's better to use ~> 2.9.0
       {:cowlib, "~> 2.9.0", override: true},


### PR DESCRIPTION
Changing dependency version for cowboy to be `>=2.7.0` to allow for other services to keep using `2.7.0` while `edgebook` can use `2.8.0`. 