### PR TITLE
Add support for SO_REUSEADDR option

### DIFF
--- a/lib/grpc/adapter/cowboy.ex
+++ b/lib/grpc/adapter/cowboy.ex
@@ -183,6 +183,7 @@ defmodule GRPC.Adapter.Cowboy do
   defp socket_opts(port, opts) do
     socket_opts = [port: port]
     socket_opts = if opts[:ip], do: [{:ip, opts[:ip]} | socket_opts], else: socket_opts
+    socket_opts = if opts[:reuseaddr], do: [{:reuseaddr, true} | socket_opts], else: socket_opts
 
     if opts[:cred] do
       opts[:cred].ssl ++


### PR DESCRIPTION
There is a long standing issue breaking tests where a gRPC mock server will listen on a port without REUSEADDR. The connections to the server may be left in the TIME_WAIT state and prevent a subsequent server from spawning and listening on the port.