### PR TITLE
[SBAPI-547] Add () to remote function call in use macro

### DIFF
--- a/lib/grpc/server.ex
+++ b/lib/grpc/server.ex
@@ -46,7 +46,7 @@ defmodule GRPC.Server do
       codecs = opts[:codecs] || [GRPC.Codec.Proto, GRPC.Codec.WebText]
       compressors = opts[:compressors] || []
 
-      Enum.each(service_mod.__rpc_calls__, fn {name, _, _} = rpc ->
+      Enum.each(service_mod.__rpc_calls__(), fn {name, _, _} = rpc ->
         func_name = name |> to_string |> Macro.underscore() |> String.to_atom()
         path = "/#{service_name}/#{name}"
         grpc_type = GRPC.Service.grpc_type(rpc)


### PR DESCRIPTION
Add some `()` to a remote function call that is part of a use macro, so as to allow compilation on elixir 1.17.

This change is backwards compatible, older versions of elixir didn't care about this
